### PR TITLE
ISSUE-498: Dismiss the miniplayer if currently played book gets deleted

### DIFF
--- a/BookPlayer/Library/DataManagement/DataManager+CoreData.swift
+++ b/BookPlayer/Library/DataManagement/DataManager+CoreData.swift
@@ -143,6 +143,9 @@ extension DataManager {
         }
 
         if book == PlayerManager.shared.currentBook {
+            NotificationCenter.default.post(name: .bookDelete,
+                                            object: nil,
+                                            userInfo: ["book": book])
             PlayerManager.shared.stop()
         }
 

--- a/BookPlayer/Library/RootViewController.swift
+++ b/BookPlayer/Library/RootViewController.swift
@@ -65,6 +65,7 @@ class RootViewController: UIViewController, UIGestureRecognizerDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(self.onBookPlay), name: .bookPlayed, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.onBookPause), name: .bookPaused, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.onBookPause), name: .bookEnd, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.onBookDelete(_:)), name: .bookDelete, object: nil)
 
         // Gestures
         self.pan = UIPanGestureRecognizer(target: self, action: #selector(self.panAction))
@@ -116,6 +117,18 @@ class RootViewController: UIViewController, UIGestureRecognizerDelegate {
     @objc private func onBookPause() {
         // Only enable the gesture to dismiss the Mini Player when the book is paused
         self.pan.isEnabled = true
+    }
+    
+    @objc private func onBookDelete(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+            let book = userInfo["book"] as? Book
+        else {
+            return
+        }
+        
+        if book == PlayerManager.shared.currentBook && !miniPlayerIsHidden {
+            self.dismissMiniPlayer()
+        }
     }
 
     // MARK: - Helpers

--- a/Shared/Extensions/Notification+BookPlayerKit.swift
+++ b/Shared/Extensions/Notification+BookPlayerKit.swift
@@ -16,6 +16,7 @@ extension Notification.Name {
     public static let bookPaused = Notification.Name("com.tortugapower.audiobookplayer.book.pause")
     public static let bookStopped = Notification.Name("com.tortugapower.audiobookplayer.book.stop")
     public static let bookEnd = Notification.Name("com.tortugapower.audiobookplayer.book.end")
+    public static let bookDelete = Notification.Name("com.tortugapower.audiobookplayer.book.delete")
     public static let bookChange = Notification.Name("com.tortugapower.audiobookplayer.book.change")
     public static let bookPlaying = Notification.Name("com.tortugapower.audiobookplayer.book.playback")
     public static let contextUpdate = Notification.Name("com.tortugapower.audiobookplayer.watch.sync")


### PR DESCRIPTION
# 🔨 PR Type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe in summary)

This PR fixes the issue of the miniplayer not being dismissed, even after the user deletes the current book.

# 📝 Summary of Changes
Changes proposed in this pull request:
- Resolves issue #498 

# 🧐🗒 Reviewer Notes

## 💁 Screen recordings after fixing
### Deleting a book that is currently playing
<img src="https://user-images.githubusercontent.com/38497249/94991337-0ec5de00-05b5-11eb-851d-0435cac27719.gif" width="300">

### Deleting a playlist containing a book that is currently playing
<img src="https://user-images.githubusercontent.com/38497249/94991441-c35fff80-05b5-11eb-9a2e-dfaee5b445f1.gif" width="300">

## 🔨 Scenarios Tested / How To Test

The miniplayer should be dismissed after a user:
- Deletes a book that is currently playing
- Deletes a playlist and its corresponding files containing a book that is currently playing

The miniplayer will not be dismissed after a user:
- Plays a book in a playlist, and deleting that playlist (without its files)

Scenarios tested on iPhone 11 Simulator (iOS 13.6)